### PR TITLE
Update mundis-validator.service

### DIFF
--- a/scripts/mundis_0.0.0-1_amd64/etc/systemd/system/mundis-validator.service
+++ b/scripts/mundis_0.0.0-1_amd64/etc/systemd/system/mundis-validator.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Mundis Validator
-After=network.target
-StartLimitIntervalSec=0
+After=local-fs.target network-online.target
+StartLimitIntervalSec=10
 
 [Service]
 Type=simple
 Restart=always
-RestartSec=1
+RestartSec=5
 User=mundis
 LimitNOFILE=1000000
 LogRateLimitIntervalSec=0


### PR DESCRIPTION
It needs to run after "local-fs.target" to have all disks mounted in case of having the external disk. and also, regarding the network, it needs the online network, not only the network.

It would be better to have more delay on restart. the os will stop service after many restarts